### PR TITLE
Chris/model

### DIFF
--- a/MERN-backend/models/user.js
+++ b/MERN-backend/models/user.js
@@ -23,8 +23,11 @@ const userSchema = mongoose.Schema({
     });
 
     const User = mongoose.model('User', userSchema);  
+    const Content = mongoose.model('Content', contentSchema)
                                                         
-module.exports = User;
+// module.exports = User;
+module.exports = Content;
+
 
 
  

--- a/MERN-backend/models/user.js
+++ b/MERN-backend/models/user.js
@@ -23,11 +23,12 @@ const userSchema = mongoose.Schema({
     });
 
     const User = mongoose.model('User', userSchema);  
-    const Content = mongoose.model('Content', contentSchema)
+//const Content = mongoose.model('Content', contentSchema)
                                                         
-// module.exports = User;
-module.exports = Content;
+module.exports = User;
+//module.exports = Content;
 
+//swap the commented out lines with the lines above them to convert to a stand alone content model.
 
 
  


### PR DESCRIPTION
Wanted to add the option for us to just design on a single model if embedded became too complicated.  Added two commented out lines (26, 29) that could be swapped out for the lines above them to turn the model into a Content model that could be manipulated directly.

This way if we want to work on parts that do simple CRUD operations on content we can, then later we can adjust them to work with an embedded model. 

This just gives us more options.